### PR TITLE
Version 1.0.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,11 +32,11 @@ To begin we need to add some podcast rss feeds. This is done one by one with the
 
     $ podcast add URL
 
-The default audio player is mplayer. If desired you can change that.
+The default audio player is mpv in no-video mode. If desired you can change that.
 
 .. code-block:: bash
 
-    $ podcast set-player mpv
+    $ podcast set-player mplayer
 
 Usage
 ~~~~~

--- a/podcast_player/__init__.py
+++ b/podcast_player/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '1.0.4'
+__version__ = '1.1.0'
 from .podcast_database import PodcastDatabase
 from .user_settings import UserSettings

--- a/podcast_player/__init__.py
+++ b/podcast_player/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '1.1.0'
+__version__ = '1.0.5'
 from .podcast_database import PodcastDatabase
 from .user_settings import UserSettings

--- a/podcast_player/cli.py
+++ b/podcast_player/cli.py
@@ -63,6 +63,10 @@ def add_podcast(url):
 
 
 def handle_choice():
+    """
+    Save the preferred media player in the user settings
+    """
+
     choice = input(">>  ")
     choice = choice.lower()
     if choice == "q":
@@ -77,42 +81,79 @@ def handle_choice():
         return int(choice)
 
 def set_player(player):
+    """
+    Save the preferred media player in the user settings
+
+    Parameters
+    ----------
+    player : string
+        The player that we pass the media url to when we play a podcast.
+    """
+
     user_settings = UserSettings()
     user_settings.set_media_player(player)
 
 def play_podcast(url):
+    """
+    Play the podcast using the user's preferred player
+    """
+
     user_settings = UserSettings()
     player = user_settings.get_media_player()
     os.system('clear')
     os.system(player + " "+ url)
 
+def get_episode_media_url(podcast_entry):
+    """
+    Extract the media URL from the podcast entry
+
+    Parameters
+    ----------
+    podcast_entry : object
+        The entry object from the feed.
+    """
+
+    links = podcast_entry["links"]
+    for link in links:
+        if "audio" in link["type"]:
+            return link["href"]
+
 def episode_menu(podcast):
     """
-    The episode menu 
+    The episode menu
     Here we list all the episodes tof the selected poodcast
     and allow the user to choose which one they want to listen to
+
+    Parameters
+    ----------
+    podcast : PodcastDatabase
+        The podcast entry from the database
     """
+
     feed = feedparser.parse(podcast.url)
     feed.entries.reverse()
     choice = ""
     os.system('clear')
-    print(podcast.name)
+
     for index, entry in enumerate(feed.entries):
         print(str(index+1) + " - " + entry['title'])
     print("b - Back")
     print("q - Quit")
     choice = handle_choice()
-    url = feed.entries[choice-1]["link"]
+
+    entry = feed.entries[choice-1]
+    url = get_episode_media_url(entry)
     play_podcast(url)
     episode_menu(podcast)
 
 def podcast_menu():
     """
-    The main menu 
+    The main menu
     Here we list all the podcasts that the user is subscribed to
     and allow the user to choose which one they want to see the episodes of
     At that point we move to the episode menu
     """
+
     os.system('clear')
     podcasts = PodcastDatabase.select()
     for podcast in podcasts:

--- a/podcast_player/user_settings.py
+++ b/podcast_player/user_settings.py
@@ -15,7 +15,7 @@ class UserSettings(object):
 
         self.config = configparser.ConfigParser()
         self.config.add_section('podcast')
-        self.config['podcast']['player'] = "mplayer"
+        self.config['podcast']['player'] = "mpv --no-video"
 
         if not os.path.isfile(self.user_config_path):
             with open(self.user_config_path, 'w') as f:


### PR DESCRIPTION
- Use the media url (which should point to the mp3 file) instead of the link (which sometimes just points to the website of the podcast.

- Change the default player to mpv in no-video mode