### PR TITLE
Adjust OPML import

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,8 +65,8 @@ For more details run with the help option
     Usage:
       podcast
       podcast add <url>
-      podcast opml <opml>
       podcast set-player <player>
+      podcast -i <opml-file>
       podcast -h | --help
       podcast --version
 

--- a/README.rst
+++ b/README.rst
@@ -33,11 +33,11 @@ To begin we need to add some podcast rss feeds. This is done one by one with the
 
     $ podcast add URL
 
-If you have an OPML file with podcast subscriptions that you would like to import then you can do so with the opml argument.
+If you have an OPML file with podcast subscriptions that you would like to import then you can do so with the -i flag.
 
 .. code-block:: bash
 
-    $ podcast opml OPMLFILE
+    $ podcast -i OPML-FILE
 
 The default audio player is mpv in no-video mode. If desired you can change that.
 

--- a/podcast_player/__init__.py
+++ b/podcast_player/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '1.3.0'
+__version__ = '1.3.1'
 from .user_settings import UserSettings

--- a/podcast_player/cli.py
+++ b/podcast_player/cli.py
@@ -255,8 +255,6 @@ def main():
     # Run the docopt
     options = docopt(__doc__, version=VERSION)
 
-    print(options)
-    
     if(options["add"]):
         add_podcast(options["<url>"])
 

--- a/podcast_player/cli.py
+++ b/podcast_player/cli.py
@@ -5,7 +5,7 @@ Usage:
   podcast
   podcast add <url>
   podcast set-player <player>
-  podcast -i <opml>
+  podcast -i <opml-file>
   podcast -h | --help
   podcast --version
 
@@ -262,7 +262,7 @@ def main():
         set_player(options["<player>"])
 
     elif(options["-i"]):
-        import_opml(options["<opml>"])
+        import_opml(options["<opml-file>"])
         
     else:
         podcast_menu()

--- a/podcast_player/cli.py
+++ b/podcast_player/cli.py
@@ -4,8 +4,8 @@ podcast
 Usage:
   podcast
   podcast add <url>
-  podcast opml <opml>
   podcast set-player <player>
+  podcast -i <opml>
   podcast -h | --help
   podcast --version
 
@@ -255,7 +255,7 @@ def main():
     # Run the docopt
     options = docopt(__doc__, version=VERSION)
 
-
+    print(options)
     
     if(options["add"]):
         add_podcast(options["<url>"])
@@ -263,7 +263,7 @@ def main():
     elif(options["set-player"]):
         set_player(options["<player>"])
 
-    elif(options["opml"]):
+    elif(options["-i"]):
         import_opml(options["<opml>"])
         
     else:


### PR DESCRIPTION
Adjusting the OPML import to use the -i flag instead of OPML argument.
